### PR TITLE
Composable effects

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -111,7 +111,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -111,10 +111,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
+      "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "StateMachine",
@@ -10,15 +11,26 @@ let package = Package(
         .watchOS(.v6)
     ],
     products: [
-        .library(name: "StateMachine", targets: ["StateMachine"])    
+        .library(name: "StateMachine", targets: ["StateMachine"])
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0")
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0")
     ],
     targets: [
+        .macro(
+            name: "StateMachineMacros",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
         .target(
             name: "StateMachine",
             dependencies: [
+                "StateMachineMacros",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0")
     ],
     targets: [
         .macro(

--- a/Sources/StateMachine/ComposableEffect.swift
+++ b/Sources/StateMachine/ComposableEffect.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 indirect public enum ComposableEffect<Effect> {
     case just(Effect)
     case merge([Self])

--- a/Sources/StateMachine/ComposableEffect.swift
+++ b/Sources/StateMachine/ComposableEffect.swift
@@ -9,7 +9,9 @@ indirect public enum ComposableEffect<Effect> {
 public extension ComposableEffect {
     
     static var none: Self { merge([]) }
-    static func merge(_ effects: Self...) -> Self { merge(effects) }
-    static func concat(_ effects: Self...) -> Self { concat(effects) }
+    static func merge(_ effects: Effect...) -> Self { merge(effects.map(Self.just)) }
+    static func merge(_ effects: Self...) -> Self { .merge(effects) }
+    static func concat(_ effects: Effect...) -> Self { concat(effects.map(Self.just)) }
+    static func concat(_ effects: Self...) -> Self { .concat(effects) }
     
 }

--- a/Sources/StateMachine/ComposableEffect.swift
+++ b/Sources/StateMachine/ComposableEffect.swift
@@ -1,0 +1,13 @@
+indirect public enum ComposableEffect<Effect> {
+    case just(Effect)
+    case merge([Self])
+    case concat([Self])
+}
+
+public extension ComposableEffect {
+    
+    static var none: Self { merge([]) }
+    static func merge(_ effects: Self...) -> Self { merge(effects) }
+    static func concat(_ effects: Self...) -> Self { concat(effects) }
+    
+}

--- a/Sources/StateMachine/ComposableEffect.swift
+++ b/Sources/StateMachine/ComposableEffect.swift
@@ -1,4 +1,10 @@
 import Foundation
+import ComposableArchitecture
+
+public protocol ComposableEffectConvertible {
+    /// Lift the current effect into a composable representation.
+    func asComposableEffect() -> ComposableEffect<Self>
+}
 
 indirect public enum ComposableEffect<Effect> {
     case just(Effect)
@@ -13,5 +19,41 @@ public extension ComposableEffect {
     static func merge(_ effects: Self...) -> Self { .merge(effects) }
     static func concat(_ effects: Effect...) -> Self { concat(effects.map(Self.just)) }
     static func concat(_ effects: Self...) -> Self { .concat(effects) }
+    
+}
+
+public extension StateMachine where
+Action : StateMachineEventConvertible,
+Action : Sendable,
+Action.Input == Input,
+Action.IOResult == IOResult,
+IOEffect : ComposableEffectConvertible
+{
+    
+    func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+        let (nextState, ioEffect) = transition
+        if let nextState { state = nextState }
+        return ioEffect.map { $0.asComposableEffect().extract(applyIOEffect(_:)) } ?? .none
+    }
+    
+}
+
+public extension ComposableEffect {
+    
+    typealias TCAEffect = ComposableArchitecture.Effect
+    
+    func extract<Action, Input, IOResult>(_ operation: @escaping (Effect) -> TCAEffect<Action>) -> TCAEffect<Action>
+    where
+    Action : StateMachineEventConvertible,
+    Action : Sendable,
+    Action.Input == Input,
+    Action.IOResult == IOResult
+    {
+        switch self {
+        case .just(let effect): operation(effect)
+        case .merge(let effects): .merge(effects.map { $0.extract(operation) })
+        case .concat(let effects): .concatenate(effects.map { $0.extract(operation) })
+        }
+    }
     
 }

--- a/Sources/StateMachine/ComposableEffect.swift
+++ b/Sources/StateMachine/ComposableEffect.swift
@@ -1,11 +1,6 @@
 import Foundation
 import ComposableArchitecture
 
-public protocol ComposableEffectConvertible {
-    /// Lift the current effect into a composable representation.
-    func asComposableEffect() -> ComposableEffect<Self>
-}
-
 indirect public enum ComposableEffect<Effect> {
     case just(Effect)
     case merge([Self])
@@ -59,7 +54,6 @@ IOEffect : ComposableEffectConvertible
         }
     }
     
-
 }
 
 public extension ComposableEffect {

--- a/Sources/StateMachine/ComposableEffect.swift
+++ b/Sources/StateMachine/ComposableEffect.swift
@@ -30,12 +30,36 @@ Action.IOResult == IOResult,
 IOEffect : ComposableEffectConvertible
 {
     
+    static func reduce(_ state: State, _ action: Action) -> Transition {
+        return switch Action.map(action) {
+        case nil: identity
+        case .input(let input)?: reduceInput(state, input)
+        case .ioResult(let ioResult)?: reduceIOResult(state, ioResult)
+        }
+    }
+    
+    func applyIOEffect(_ ioEffect: IOEffect) -> Effect<Action> {
+        .run { send in
+            for try await result in runIOEffect(ioEffect) {
+                await send(.ioResult(result))
+            }
+        }
+    }
+    
     func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
         let (nextState, ioEffect) = transition
         if let nextState { state = nextState }
         return ioEffect.map { $0.asComposableEffect().extract(applyIOEffect(_:)) } ?? .none
     }
     
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            let transition = Self.reduce(state, action)
+            return apply(transition, to: &state)
+        }
+    }
+    
+
 }
 
 public extension ComposableEffect {

--- a/Sources/StateMachine/ComposableEffect.swift
+++ b/Sources/StateMachine/ComposableEffect.swift
@@ -17,45 +17,6 @@ public extension ComposableEffect {
     
 }
 
-public extension StateMachine where
-Action : StateMachineEventConvertible,
-Action : Sendable,
-Action.Input == Input,
-Action.IOResult == IOResult,
-IOEffect : ComposableEffectConvertible
-{
-    
-    static func reduce(_ state: State, _ action: Action) -> Transition {
-        return switch Action.map(action) {
-        case nil: identity
-        case .input(let input)?: reduceInput(state, input)
-        case .ioResult(let ioResult)?: reduceIOResult(state, ioResult)
-        }
-    }
-    
-    func applyIOEffect(_ ioEffect: IOEffect) -> Effect<Action> {
-        .run { send in
-            for try await result in runIOEffect(ioEffect) {
-                await send(.ioResult(result))
-            }
-        }
-    }
-    
-    func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
-        let (nextState, ioEffect) = transition
-        if let nextState { state = nextState }
-        return ioEffect.map { $0.asComposableEffect().extract(applyIOEffect(_:)) } ?? .none
-    }
-    
-    var body: some Reducer<State, Action> {
-        Reduce { state, action in
-            let transition = Self.reduce(state, action)
-            return apply(transition, to: &state)
-        }
-    }
-    
-}
-
 public extension ComposableEffect {
     
     typealias TCAEffect = ComposableArchitecture.Effect

--- a/Sources/StateMachine/ComposableEffectConvertible.swift
+++ b/Sources/StateMachine/ComposableEffectConvertible.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol ComposableEffectConvertible {
+    /// Lift the current effect into a composable representation.
+    func asComposableEffect() -> ComposableEffect<Self>
+}

--- a/Sources/StateMachine/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachine/ComposableEffectMembersMacro.swift
@@ -1,4 +1,5 @@
 @attached(member, names: arbitrary)
+@attached(extension, conformances: ComposableEffectConvertible)
 public macro ComposableEffectMembers() = #externalMacro(
     module: "StateMachineMacros",
     type: "ComposableEffectMembersMacro"

--- a/Sources/StateMachine/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachine/ComposableEffectMembersMacro.swift
@@ -1,6 +1,6 @@
 @attached(member, names: arbitrary)
 @attached(extension, conformances: ComposableEffectConvertible)
-public macro ComposableEffectMembers() = #externalMacro(
+public macro ComposableEffect() = #externalMacro(
     module: "StateMachineMacros",
     type: "ComposableEffectMembersMacro"
 )

--- a/Sources/StateMachine/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachine/ComposableEffectMembersMacro.swift
@@ -1,0 +1,5 @@
+@attached(member, names: arbitrary)
+public macro ComposableEffectMembers() = #externalMacro(
+    module: "StateMachineMacros",
+    type: "ComposableEffectMembersMacro"
+)

--- a/Sources/StateMachine/EffectRunnerMacro.swift
+++ b/Sources/StateMachine/EffectRunnerMacro.swift
@@ -1,0 +1,6 @@
+@attached(member, names: arbitrary)
+@attached(memberAttribute)
+public macro ComposableEffectRunner() = #externalMacro(
+    module: "StateMachineMacros",
+    type: "EffectRunnerMacro"
+)

--- a/Sources/StateMachine/StateMachine.swift
+++ b/Sources/StateMachine/StateMachine.swift
@@ -7,7 +7,7 @@ public protocol StateMachine : Reducer {
     associatedtype IOResult : Sendable
     typealias IOResultStream = AsyncStream<IOResult>
     
-    typealias Transition = (State?, IOEffect?)
+    typealias Transition = (State?, ComposableEffect<IOEffect>)
     
     static func reduceInput(_ state: State, _ input: Input) -> Transition
     static func reduceIOResult(_ state: State, _ ioResult: IOResult) -> Transition
@@ -15,10 +15,12 @@ public protocol StateMachine : Reducer {
 }
 
 public extension StateMachine {
-    static var undefined: Transition { (nil, nil) }
-    static var identity: Transition { (nil, nil) }
-    static func nextState(_ state: State) -> Transition { (state, nil) }
-    static func run(_ effect: IOEffect) -> Transition { (nil, effect) }
-    static func transition(_ state: State, effect: IOEffect) -> Transition { (state, effect) }
-    static func unsafe(_ action: @escaping () -> Void) -> Transition { action(); return (nil, nil) }
+    static var undefined: Transition { (nil, .none) }
+    static var identity: Transition { (nil, .none) }
+    static func nextState(_ state: State) -> Transition { (state, .none) }
+    static func run(_ effect: IOEffect) -> Transition { (nil, .just(effect)) }
+    static func run(_ effect: ComposableEffect<IOEffect>) -> Transition { (nil, effect) }
+    static func transition(_ state: State, _ effect: IOEffect) -> Transition { (state, .just(effect)) }
+    static func transition(_ state: State, _ effect: ComposableEffect<IOEffect>) -> Transition { (state, effect) }
+    static func unsafe(_ action: @escaping () -> Void) -> Transition { action(); return (nil, .none) }
 }

--- a/Sources/StateMachine/StateMachine.swift
+++ b/Sources/StateMachine/StateMachine.swift
@@ -7,7 +7,7 @@ public protocol StateMachine : Reducer {
     associatedtype IOResult : Sendable
     typealias IOResultStream = AsyncStream<IOResult>
     
-    typealias Transition = (State?, ComposableEffect<IOEffect>)
+    typealias Transition = (State?, IOEffect?)
     
     static func reduceInput(_ state: State, _ input: Input) -> Transition
     static func reduceIOResult(_ state: State, _ ioResult: IOResult) -> Transition
@@ -15,12 +15,10 @@ public protocol StateMachine : Reducer {
 }
 
 public extension StateMachine {
-    static var undefined: Transition { (nil, .none) }
-    static var identity: Transition { (nil, .none) }
-    static func nextState(_ state: State) -> Transition { (state, .none) }
-    static func run(_ effect: IOEffect) -> Transition { (nil, .just(effect)) }
-    static func run(_ effect: ComposableEffect<IOEffect>) -> Transition { (nil, effect) }
-    static func transition(_ state: State, _ effect: IOEffect) -> Transition { (state, .just(effect)) }
-    static func transition(_ state: State, _ effect: ComposableEffect<IOEffect>) -> Transition { (state, effect) }
-    static func unsafe(_ action: @escaping () -> Void) -> Transition { action(); return (nil, .none) }
+    static var undefined: Transition { (nil, nil) }
+    static var identity: Transition { (nil, nil) }
+    static func nextState(_ state: State) -> Transition { (state, nil) }
+    static func run(_ effect: IOEffect) -> Transition { (nil, effect) }
+    static func transition(_ state: State, _ effect: IOEffect) -> Transition { (state, effect) }
+    static func unsafe(_ action: @escaping () -> Void) -> Transition { action(); return (nil, nil) }
 }

--- a/Sources/StateMachine/StateMachineEventConvertible.swift
+++ b/Sources/StateMachine/StateMachineEventConvertible.swift
@@ -36,33 +36,13 @@ Action.IOResult == IOResult
     func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
         let (nextState, ioEffect) = transition
         if let nextState { state = nextState }
-        return ioEffect.extract(applyIOEffect(_:))
+        return ioEffect.map(applyIOEffect(_:)) ?? .none
     }
     
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             let transition = Self.reduce(state, action)
             return apply(transition, to: &state)
-        }
-    }
-    
-}
-
-public extension ComposableEffect {
-    
-    typealias TCAEffect = ComposableArchitecture.Effect
-    
-    func extract<Action, Input, IOResult>(_ operation: @escaping (Effect) -> TCAEffect<Action>) -> TCAEffect<Action>
-    where
-    Action : StateMachineEventConvertible,
-    Action : Sendable,
-    Action.Input == Input,
-    Action.IOResult == IOResult
-    {
-        switch self {
-        case .just(let effect): operation(effect)
-        case .merge(let effects): .merge(effects.map { $0.extract(operation) })
-        case .concat(let effects): .concatenate(effects.map { $0.extract(operation) })
         }
     }
     

--- a/Sources/StateMachine/StateMachineEventConvertible.swift
+++ b/Sources/StateMachine/StateMachineEventConvertible.swift
@@ -12,7 +12,6 @@ public protocol StateMachineEventConvertible<Input, IOResult> {
 
 public extension StateMachine where
 Action : StateMachineEventConvertible,
-Action : Sendable,
 Action.Input == Input,
 Action.IOResult == IOResult
 {

--- a/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
@@ -1,0 +1,114 @@
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+@main
+struct StateMachinePlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        ComposableEffectMembersMacro.self
+    ]
+}
+
+public struct ComposableEffectMembersMacro: MemberMacro {
+    public static func expansion(
+        of attribute: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+            throw MacroError.message("@ComposableEffectMembers can only be attached to enums")
+        }
+        let caseDecls = enumDecl.memberBlock.members.compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
+        guard caseDecls.isNotEmpty else {
+            throw MacroError.message("@ComposableEffectMembers requires at least one case")
+        }
+        let accessModifier = enumDecl.effectiveAccessModifier
+        return caseDecls.flatMap { decl in
+            decl.elements.map { element in
+                buildFunctionDecl(for: element, accessModifier: accessModifier)
+            }
+        }
+    }
+    
+    private static func buildFunctionDecl(
+        for element: EnumCaseElementSyntax,
+        accessModifier: String?
+    ) -> DeclSyntax {
+        let name = element.name.text
+        let parameterStrings: [(declaration: String, argument: String)]
+        if let parameters = element.parameterClause?.parameters {
+            parameterStrings = parameters.enumerated().map { index, parameter in
+                parameter.render(index: index)
+            }
+        } else {
+            parameterStrings = []
+        }
+        let parameterList = parameterStrings.map { $0.declaration }.joined(separator: ", ")
+        let argumentList = parameterStrings.map { $0.argument }.joined(separator: ", ")
+        let parametersClause = "(\(parameterList))"
+        let argumentClause = argumentList.isEmpty ? "" : "(\(argumentList))"
+        let accessPrefix = accessModifier.map { "\($0) " } ?? ""
+        let functionDecl: DeclSyntax = """
+        \(raw: accessPrefix)static func \(raw: name)\(raw: parametersClause) -> ComposableEffect<Self> {
+            .just(.\(raw: name)\(raw: argumentClause))
+        }
+        """
+        return functionDecl
+    }
+}
+
+private extension EnumDeclSyntax {
+    var effectiveAccessModifier: String? {
+        let supported = Set(["public", "package"])
+        for modifier in modifiers {
+            let name = modifier.name.text
+            if supported.contains(name) {
+                return name
+            }
+        }
+        return nil
+    }
+}
+
+private extension EnumCaseParameterSyntax {
+    func render(index: Int) -> (declaration: String, argument: String) {
+        let internalName = (secondName ?? firstName)?.text ?? "value\(index)"
+        let typeDescription = type.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let externalName = firstName?.text
+        let declaration: String
+        if let externalName {
+            if externalName == "_" {
+                declaration = "_ \(internalName): \(typeDescription)"
+            } else if secondName == nil {
+                declaration = "\(externalName): \(typeDescription)"
+            } else {
+                declaration = "\(externalName) \(internalName): \(typeDescription)"
+            }
+        } else {
+            declaration = "_ \(internalName): \(typeDescription)"
+        }
+        let argument: String
+        if let externalName, externalName != "_" {
+            argument = "\(externalName): \(internalName)"
+        } else {
+            argument = internalName
+        }
+        return (declaration, argument)
+    }
+}
+
+extension Collection {
+    var isNotEmpty: Bool { !isEmpty }
+}
+
+public enum MacroError: Error, CustomStringConvertible {
+    case message(String)
+    
+    public var description: String {
+        switch self {
+        case .message(let message): return message
+        }
+    }
+}
+

--- a/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
@@ -10,7 +10,7 @@ struct StateMachinePlugin: CompilerPlugin {
     ]
 }
 
-public struct ComposableEffectMembersMacro: MemberMacro {
+public struct ComposableEffectMembersMacro: MemberMacro, ExtensionMacro {
     public static func expansion(
         of attribute: AttributeSyntax,
         providingMembersOf declaration: some DeclGroupSyntax,
@@ -23,38 +23,70 @@ public struct ComposableEffectMembersMacro: MemberMacro {
         guard caseDecls.isNotEmpty else {
             throw MacroError.message("@ComposableEffectMembers requires at least one case")
         }
+        
+        let existingCaseNames = caseDecls.flatMap { $0.elements.map(\.name.text) }
+        if existingCaseNames.contains("merge") || existingCaseNames.contains("concat") {
+            throw MacroError.message("@ComposableEffectMembers cannot be applied to enums that already declare merge/concat cases")
+        }
+        
         let accessModifier = enumDecl.effectiveAccessModifier
-        return caseDecls.flatMap { decl in
-            decl.elements.map { element in
-                buildFunctionDecl(for: element, accessModifier: accessModifier)
-            }
-        }
-    }
-    
-    private static func buildFunctionDecl(
-        for element: EnumCaseElementSyntax,
-        accessModifier: String?
-    ) -> DeclSyntax {
-        let name = element.name.text
-        let parameterStrings: [(declaration: String, argument: String)]
-        if let parameters = element.parameterClause?.parameters {
-            parameterStrings = parameters.enumerated().map { index, parameter in
-                parameter.render(index: index)
-            }
-        } else {
-            parameterStrings = []
-        }
-        let parameterList = parameterStrings.map { $0.declaration }.joined(separator: ", ")
-        let argumentList = parameterStrings.map { $0.argument }.joined(separator: ", ")
-        let parametersClause = "(\(parameterList))"
-        let argumentClause = argumentList.isEmpty ? "" : "(\(argumentList))"
         let accessPrefix = accessModifier.map { "\($0) " } ?? ""
-        let functionDecl: DeclSyntax = """
-        \(raw: accessPrefix)static func \(raw: name)\(raw: parametersClause) -> ComposableEffect<Self> {
-            .just(.\(raw: name)\(raw: argumentClause))
+        let composableCases: [DeclSyntax] = [
+            "\(raw: accessPrefix)indirect case merge([Self])",
+            "\(raw: accessPrefix)indirect case concat([Self])"
+        ]
+        
+        let factories: [DeclSyntax] = [
+            """
+            \(raw: accessPrefix)static func merge(_ effects: Self...) -> Self {
+                .merge(effects)
+            }
+            """,
+            """
+            \(raw: accessPrefix)static func concat(_ effects: Self...) -> Self {
+                .concat(effects)
+            }
+            """
+        ]
+        
+        let leafCaseNames = existingCaseNames.filter { $0 != "merge" && $0 != "concat" }
+        let leafSwitchCases = leafCaseNames
+            .map { "case .\($0): return .just(self)" }
+            .joined(separator: "\n            ")
+        
+        let asComposableEffectDecl: DeclSyntax = """
+        \(raw: accessPrefix)func asComposableEffect() -> ComposableEffect<Self> {
+            switch self {
+            case .merge(let effects):
+                return .merge(effects.map { $0.asComposableEffect() })
+            case .concat(let effects):
+                return .concat(effects.map { $0.asComposableEffect() })
+            \(raw: leafSwitchCases.isEmpty ? "" : leafSwitchCases)
+            }
         }
         """
-        return functionDecl
+        
+        return composableCases + factories + [asComposableEffectDecl]
+    }
+    
+    public static func expansion(
+        of attribute: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard declaration.is(EnumDeclSyntax.self) else {
+            throw MacroError.message("@ComposableEffectMembers can only be attached to enums")
+        }
+        
+        let typeDescription = type.trimmedDescription
+        let protocolList = protocols.map { $0.trimmedDescription }.joined(separator: ", ")
+        guard !protocolList.isEmpty else { return [] }
+        
+        let decl: DeclSyntax = "extension \(raw: typeDescription): \(raw: protocolList) { }"
+        guard let ext = decl.as(ExtensionDeclSyntax.self) else { return [] }
+        return [ext]
     }
 }
 
@@ -71,33 +103,6 @@ private extension EnumDeclSyntax {
     }
 }
 
-private extension EnumCaseParameterSyntax {
-    func render(index: Int) -> (declaration: String, argument: String) {
-        let internalName = (secondName ?? firstName)?.text ?? "value\(index)"
-        let typeDescription = type.description.trimmingCharacters(in: .whitespacesAndNewlines)
-        let externalName = firstName?.text
-        let declaration: String
-        if let externalName {
-            if externalName == "_" {
-                declaration = "_ \(internalName): \(typeDescription)"
-            } else if secondName == nil {
-                declaration = "\(externalName): \(typeDescription)"
-            } else {
-                declaration = "\(externalName) \(internalName): \(typeDescription)"
-            }
-        } else {
-            declaration = "_ \(internalName): \(typeDescription)"
-        }
-        let argument: String
-        if let externalName, externalName != "_" {
-            argument = "\(externalName): \(internalName)"
-        } else {
-            argument = internalName
-        }
-        return (declaration, argument)
-    }
-}
-
 extension Collection {
     var isNotEmpty: Bool { !isEmpty }
 }
@@ -109,6 +114,12 @@ public enum MacroError: Error, CustomStringConvertible {
         switch self {
         case .message(let message): return message
         }
+    }
+}
+
+private extension SyntaxProtocol {
+    var trimmedDescription: String {
+        description.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
@@ -6,7 +6,8 @@ import SwiftSyntaxMacros
 @main
 struct StateMachinePlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        ComposableEffectMembersMacro.self
+        ComposableEffectMembersMacro.self,
+        EffectRunnerMacro.self
     ]
 }
 
@@ -32,18 +33,18 @@ public struct ComposableEffectMembersMacro: MemberMacro, ExtensionMacro {
         let accessModifier = enumDecl.effectiveAccessModifier
         let accessPrefix = accessModifier.map { "\($0) " } ?? ""
         let composableCases: [DeclSyntax] = [
-            "\(raw: accessPrefix)indirect case merge([Self])",
-            "\(raw: accessPrefix)indirect case concat([Self])"
+            "indirect case merge([Self])",
+            "indirect case concat([Self])"
         ]
         
         let factories: [DeclSyntax] = [
             """
-            \(raw: accessPrefix)static func merge(_ effects: Self...) -> Self {
+            static func merge(_ effects: Self...) -> Self {
                 .merge(effects)
             }
             """,
             """
-            \(raw: accessPrefix)static func concat(_ effects: Self...) -> Self {
+            static func concat(_ effects: Self...) -> Self {
                 .concat(effects)
             }
             """

--- a/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
@@ -18,16 +18,16 @@ public struct ComposableEffectMembersMacro: MemberMacro, ExtensionMacro {
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
         guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
-            throw MacroError.message("@ComposableEffectMembers can only be attached to enums")
+            throw MacroError.message("@ComposableEffect can only be attached to enums")
         }
         let caseDecls = enumDecl.memberBlock.members.compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
         guard caseDecls.isNotEmpty else {
-            throw MacroError.message("@ComposableEffectMembers requires at least one case")
+            throw MacroError.message("@ComposableEffect requires at least one case")
         }
         
         let existingCaseNames = caseDecls.flatMap { $0.elements.map(\.name.text) }
         if existingCaseNames.contains("merge") || existingCaseNames.contains("concat") {
-            throw MacroError.message("@ComposableEffectMembers cannot be applied to enums that already declare merge/concat cases")
+            throw MacroError.message("@ComposableEffect cannot be applied to enums that already declare merge/concat cases")
         }
         
         let accessModifier = enumDecl.effectiveAccessModifier
@@ -78,7 +78,7 @@ public struct ComposableEffectMembersMacro: MemberMacro, ExtensionMacro {
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         guard declaration.is(EnumDeclSyntax.self) else {
-            throw MacroError.message("@ComposableEffectMembers can only be attached to enums")
+            throw MacroError.message("@ComposableEffect can only be attached to enums")
         }
         
         let typeDescription = type.trimmedDescription

--- a/Sources/StateMachineMacros/EffectRunnerMacro.swift
+++ b/Sources/StateMachineMacros/EffectRunnerMacro.swift
@@ -1,0 +1,190 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct EffectRunnerMacro: MemberMacro, MemberAttributeMacro {
+    public static func expansion(
+        of attribute: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        let info = try EffectRunnerAnalyzer.analyze(declaration: declaration)
+        return [info.makeEffectHandlerProtocol(), info.makeRunIOEffect()]
+    }
+    
+    public static func expansion(
+        of attribute: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingAttributesFor member: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AttributeSyntax] {
+        guard let enumDecl = member.as(EnumDeclSyntax.self), enumDecl.name.text == "IOEffect" else {
+            return []
+        }
+        if enumDecl.hasAttribute(named: "ComposableEffectMembers") {
+            return []
+        }
+        return ["@ComposableEffectMembers"]
+    }
+}
+
+private struct EffectRunnerAnalyzer {
+    let parentName: String
+    let ioEffectCases: [IOEffectCase]
+    let parentDecl: DeclGroupSyntax
+    
+    static func analyze(declaration: some DeclGroupSyntax) throws -> Self {
+        let parentName: String
+        let parentDecl: DeclGroupSyntax
+        if let structDecl = declaration.as(StructDeclSyntax.self) {
+            parentName = structDecl.name.text
+            parentDecl = structDecl
+        } else if let actorDecl = declaration.as(ActorDeclSyntax.self) {
+            parentName = actorDecl.name.text
+            parentDecl = actorDecl
+        } else {
+            throw MacroError.message("@EffectRunner can only be attached to a struct or actor")
+        }
+        guard let ioEffectEnum = declaration.memberBlock.members
+            .compactMap({ $0.decl.as(EnumDeclSyntax.self) })
+            .first(where: { $0.name.text == "IOEffect" }) else {
+            throw MacroError.message("@EffectRunner requires a nested enum named IOEffect")
+        }
+        if ioEffectEnum.containsCase(named: "merge") || ioEffectEnum.containsCase(named: "concat") {
+            throw MacroError.message("@EffectRunner should not be used when IOEffect already declares merge/concat")
+        }
+        let cases = try ioEffectEnum.collectLeafCases()
+        return .init(parentName: parentName, ioEffectCases: cases, parentDecl: parentDecl)
+    }
+    
+    func makeRunIOEffect() -> DeclSyntax {
+        let leafSwitchCases = ioEffectCases
+            .map { $0.makeSwitchCase() }
+            .joined(separator: "\n        ")
+        let access = accessPrefix
+        return """
+        \(raw: access)func runIOEffect(_ ioEffect: IOEffect) -> IOResultStream {
+            switch ioEffect {
+            case .merge:
+                return .init { $0.finish() }
+            case .concat:
+                return .init { $0.finish() }
+            \(raw: leafSwitchCases)
+            }
+        }
+        """
+    }
+
+    func makeEffectHandlerProtocol() -> DeclSyntax {
+        let protocolName = "EffectRunner"
+        let requirementList = ioEffectCases
+            .map { $0.makeHandlerRequirement(parentName: parentName) }
+            .joined(separator: "\n    ")
+        return """
+        private protocol \(raw: protocolName) {
+            \(raw: requirementList)
+        }
+        """
+    }
+}
+
+private extension EffectRunnerAnalyzer {
+    var accessPrefix: String {
+        parentAccessModifier.map { $0 + " " } ?? ""
+    }
+    
+    var parentAccessModifier: String? {
+        for modifier in parentDecl.modifiers {
+            let text = modifier.name.text
+            if text == "public" || text == "package" {
+                return text
+            }
+        }
+        return nil
+    }
+}
+
+private struct IOEffectCase {
+    struct Parameter {
+        let external: String?
+        let internalName: String
+        let type: String
+        
+        var signatureFragment: String {
+            "_ \(internalName): \(type)"
+        }
+        
+        var callArgument: String {
+            internalName
+        }
+    }
+    
+    let name: String
+    let parameters: [Parameter]
+    
+    var handlerName: String {
+        "run" + name.prefix(1).uppercased() + name.dropFirst()
+    }
+    
+    func makeHandlerRequirement(parentName: String) -> String {
+        let params = parameters.map { $0.signatureFragment }.joined(separator: ", ")
+        return "func \(handlerName)(\(params)) -> \(parentName).IOResultStream"
+    }
+    
+    func makeSwitchCase() -> String {
+        let bindings = parameters.map { "let \($0.internalName)" }.joined(separator: ", ")
+        let patternSuffix = bindings.isEmpty ? "" : "(\(bindings))"
+        let arguments = parameters.map { $0.callArgument }.joined(separator: ", ")
+        let callSuffix = arguments.isEmpty ? "" : "(\(arguments))"
+        return "case .\(name)\(patternSuffix): return self.\(handlerName)\(callSuffix)"
+    }
+}
+
+private extension EnumDeclSyntax {
+    func collectLeafCases() throws -> [IOEffectCase] {
+        var results: [IOEffectCase] = []
+        for member in memberBlock.members {
+            guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
+            for element in caseDecl.elements {
+                let caseName = element.name.text
+                guard caseName != "merge", caseName != "concat" else { continue }
+                let paramCount = element.parameterClause?.parameters.count ?? 0
+                let parameters = element.parameterClause?.parameters.enumerated().map { index, param -> IOEffectCase.Parameter in
+                    let type = param.type.trimmedDescription
+                    let external = param.firstName?.text
+                    let fallback = paramCount == 1 ? "arg" : "arg\(index + 1)"
+                    let internalName = param.secondName?.text ?? external ?? fallback
+                    return .init(external: external, internalName: internalName, type: type)
+                } ?? []
+                results.append(.init(name: caseName, parameters: parameters))
+            }
+        }
+        return results
+    }
+    
+    func containsCase(named name: String) -> Bool {
+        for member in memberBlock.members {
+            guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
+            if caseDecl.elements.contains(where: { $0.name.text == name }) {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+private extension SyntaxProtocol {
+    var trimmedDescription: String {
+        description.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private extension DeclSyntaxProtocol {
+    func hasAttribute(named name: String) -> Bool {
+        guard let attributes = self.asProtocol(WithAttributesSyntax.self)?.attributes else { return false }
+        return attributes.contains { attr in
+            guard let attribute = attr.as(AttributeSyntax.self) else { return false }
+            return attribute.attributeName.trimmedDescription == name
+        }
+    }
+}

--- a/TCA-SM.instructions.md
+++ b/TCA-SM.instructions.md
@@ -99,10 +99,10 @@ extension StateMachine {
 
 ### ComposableEffect Macro
 
-Add the `@ComposableEffectMembers` attribute to any effect enum to synthesize scoped helpers that lift enum cases into `ComposableEffect` values. This keeps reducer code terse even when mixing nested combinators:
+Add the `@ComposableEffect` attribute to any effect enum to synthesize scoped helpers that lift enum cases into `ComposableEffect` values. This keeps reducer code terse even when mixing nested combinators:
 
 ```swift
-@ComposableEffectMembers
+@ComposableEffect
 enum IOEffect {
     case fetch(Int)
     case print(Int)

--- a/TCA-SM.instructions.md
+++ b/TCA-SM.instructions.md
@@ -97,6 +97,33 @@ extension StateMachine {
 }
 ```
 
+### ComposableEffect Macro
+
+Add the `@ComposableEffectMembers` attribute to any effect enum to synthesize scoped helpers that lift enum cases into `ComposableEffect` values. This keeps reducer code terse even when mixing nested combinators:
+
+```swift
+@ComposableEffectMembers
+enum IOEffect {
+    case fetch(Int)
+    case print(Int)
+}
+
+static func reduceInput(_ state: State, _ input: Input) -> Transition {
+    switch input {
+    case .numberFactButtonTapped:
+        run(.concat(
+            .fetch(state.count),
+            .merge(
+                .print(state.count),
+                .print(state.count * 2)
+            )
+        ))
+    }
+}
+```
+
+The macro-generated functions honor the enum's access control, so `public enum` cases yield `public static func fetch(...) -> ComposableEffect` helpers that downstream modules can call without wrapping cases in `.just` manually.
+
 ## Key Design Principles
 
 ### 1. Effect Abstraction


### PR DESCRIPTION
- Instead of a single `IOEffect` per `Input`, multiple effects could be run concurrently, using `.merge`, or in sequence, using `.concat`.