### PR TITLE
[lib] Update: Add CasePathable conformance to StateMachineEvent

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -111,7 +111,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0")
     ],
     targets: [
@@ -31,7 +32,8 @@ let package = Package(
             name: "StateMachine",
             dependencies: [
                 "StateMachineMacros",
-                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+                .product(name: "CasePaths", package: "swift-case-paths")
             ]
         )
     ]

--- a/Sources/StateMachine/StateMachineEvent.swift
+++ b/Sources/StateMachine/StateMachineEvent.swift
@@ -1,5 +1,7 @@
 import Foundation
+import ComposableArchitecture
 
+@dynamicMemberLookup
 public enum StateMachineEvent<Input, IOResult> {
     case input(Input)
     case ioResult(IOResult)
@@ -12,3 +14,45 @@ extension StateMachineEvent : StateMachineEventConvertible {
     public static func map(_ action: Self) -> StateMachineEvent<Input, IOResult>? { action }
     
 }
+
+public extension StateMachineEvent {
+    
+    struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+        
+        public subscript(
+            root: StateMachineEvent<Input, IOResult>
+        ) -> CasePaths.PartialCaseKeyPath<StateMachineEvent<Input, IOResult>> {
+            if root.is(\.input) { return \.input }
+            if root.is(\.ioResult) { return \.ioResult }
+            return \.never
+        }
+        
+        public var input: CasePaths.AnyCasePath<StateMachineEvent<Input, IOResult>, Input> {
+            ._$embed(StateMachineEvent.input) {
+                guard case let .input(v0) = $0 else { return nil }
+                return v0
+            }
+        }
+        
+        public var ioResult: CasePaths.AnyCasePath<StateMachineEvent<Input, IOResult>, IOResult> {
+            ._$embed(StateMachineEvent.ioResult) {
+                guard case let .ioResult(v0) = $0 else { return nil }
+                return v0
+            }
+        }
+        
+        public func makeIterator(
+        ) -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<StateMachineEvent<Input, IOResult>>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<StateMachineEvent<Input, IOResult>>] = []
+            allCasePaths.append(\.input)
+            allCasePaths.append(\.ioResult)
+            return allCasePaths.makeIterator()
+        }
+        
+    }
+    
+    static var allCasePaths: AllCasePaths { AllCasePaths() }
+    
+}
+
+extension StateMachineEvent: CasePaths.CasePathable, CasePaths.CasePathIterable { }


### PR DESCRIPTION
## Summary
Adds manual `@CasePathable` conformance to `StateMachineEvent` to enable seamless integration with TCA's scoping mechanisms.

## Changes
- Added `swift-case-paths` package dependency
- Implemented `CasePathable` and `CasePathIterable` conformance for `StateMachineEvent<Input, IOResult>`
- Added `@dynamicMemberLookup` attribute for case path access
- Manually implemented `AllCasePaths` struct with:
  - Case path reflection via subscript
  - `input` and `ioResult` case paths
  - Iterator support for case path enumeration

## Motivation
Without `CasePathable` conformance, `StateMachineEvent` cannot be used effectively with TCA's `Scope` reducer and other case-path-based APIs. This implementation provides the same functionality as the `@CasePathable` macro would generate, but is done manually for explicit control over the generic enum implementation.

## Testing
- Enables `Scope(state:action:)` to work with `StateMachineEvent` as the action type
- Compatible with TCA's composition patterns for nested reducers
