### PR TITLE
[0.1.2] `@ForwardValue` macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,13 @@ let package = Package(
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "CasePaths", package: "swift-case-paths"),
             ]
+        ),
+        .testTarget(
+            name: "StateMachineMacrosTests",
+            dependencies: [
+                "StateMachineMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
         )
     ]
 )

--- a/Sources/StateMachine/Macros.swift
+++ b/Sources/StateMachine/Macros.swift
@@ -104,6 +104,9 @@ public macro NestedState() = #externalMacro(
 /// Example:
 /// ```swift
 /// enum Input {
+///     @Forward(CounterFeature.Input.self)
+///     case counter(CounterFeature.Input)
+///
 ///     @Forward(CounterFeature.Input.incrementTapped)
 ///     case counterIncrement
 ///
@@ -114,6 +117,9 @@ public macro NestedState() = #externalMacro(
 /// enum IOResult {
 ///     @Forward(PresetsFeature.IOResult.self)
 ///     case presetsResult(PresetsFeature.IOResult)
+///
+///     @Forward(PresetsFeature.IOResult.loaded)
+///     case presetsLoaded([Preset])
 /// }
 /// ```
 @attached(peer)

--- a/Sources/StateMachine/Macros.swift
+++ b/Sources/StateMachine/Macros.swift
@@ -130,15 +130,20 @@ public macro Forward<T>(_ target: T) = #externalMacro(
 
 // MARK: - ForwardValue
 
-/// Marks an Input case as forwarding its associated value as the child's entire input.
+/// Marks an Input or IOResult case as forwarding its associated value as the child's entire value.
 ///
-/// Use this when the child feature's `Input` is a value type rather than an enum.
+/// Use this when the child feature's `Input` or `IOResult` is a value type rather than an enum case.
 ///
 /// Example:
 /// ```swift
 /// enum Input {
 ///     @ForwardValue(NumberFactLoader.Input.self)
 ///     case load(Int)
+/// }
+///
+/// enum IOResult {
+///     @ForwardValue(NumberFactLoader.IOResult.self)
+///     case loaded(String)
 /// }
 /// ```
 @attached(peer)

--- a/Sources/StateMachine/Macros.swift
+++ b/Sources/StateMachine/Macros.swift
@@ -122,6 +122,25 @@ public macro Forward<T>(_ target: T) = #externalMacro(
     type: "ForwardMacro"
 )
 
+// MARK: - ForwardValue
+
+/// Marks an Input case as forwarding its associated value as the child's entire input.
+///
+/// Use this when the child feature's `Input` is a value type rather than an enum.
+///
+/// Example:
+/// ```swift
+/// enum Input {
+///     @ForwardValue(NumberFactLoader.Input.self)
+///     case load(Int)
+/// }
+/// ```
+@attached(peer)
+public macro ForwardValue<T>(_ target: T.Type) = #externalMacro(
+    module: "StateMachineMacros",
+    type: "ForwardValueMacro"
+)
+
 // MARK: - NestedFeature
 
 /// Declares a nested feature for edge cases like computed properties.

--- a/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
+++ b/Sources/StateMachineMacros/ComposableEffectMembersMacro.swift
@@ -12,6 +12,7 @@ struct StateMachinePlugin: CompilerPlugin {
         ComposableStateMachineMacro.self,
         NestedStateMacro.self,
         ForwardMacro.self,
+        ForwardValueMacro.self,
         NestedFeatureMacro.self,
         // Core macro for Action typealias
         StateMachineMacro.self,

--- a/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
+++ b/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
@@ -177,6 +177,15 @@ private struct StateMachineAnalyzer {
                     requiresWholeEnum: isValueForward
                 )
 
+                if targetInfo.isWholeEnumForward && !isValueForward {
+                    try validateWholeEnumForward(
+                        enumName: enumDecl.name.text,
+                        caseName: caseName,
+                        associatedValues: associatedValues,
+                        targetType: "\(targetInfo.featureName).\(targetInfo.enumType)"
+                    )
+                }
+
                 forwards.append(ForwardInfo(
                     parentCaseName: caseName,
                     associatedValues: associatedValues,
@@ -191,6 +200,17 @@ private struct StateMachineAnalyzer {
         }
 
         return forwards
+    }
+
+    private static func validateWholeEnumForward(
+        enumName: String,
+        caseName: String,
+        associatedValues: [AssociatedValue],
+        targetType: String
+    ) throws {
+        guard associatedValues.count == 1, associatedValues[0].type == targetType else {
+            throw MacroError.message("Whole-enum @Forward on \(enumName).\(caseName) requires exactly one associated value of type \(targetType)")
+        }
     }
 
     private static func findAttribute(named name: String, in caseDecl: EnumCaseDeclSyntax) -> AttributeSyntax? {
@@ -380,6 +400,9 @@ private struct StateMachineAnalyzer {
                     let valueForwarding = makeValueInputForwarding(forward.associatedValues)
                     return "case .\(forward.parentCaseName)\(valueForwarding.pattern): return .input(\(valueForwarding.call))"
                 }
+                if forward.isWholeEnumForward {
+                    return "case .\(forward.parentCaseName)(let childInput): return .input(childInput)"
+                }
                 let valueForwarding = makeValueForwarding(forward.associatedValues)
                 return "case .\(forward.parentCaseName)\(valueForwarding.pattern): return .input(.\(forward.targetCaseName!)\(valueForwarding.call))"
             }
@@ -448,8 +471,8 @@ private struct StateMachineAnalyzer {
                         // Whole enum forward: .ioResult(result) -> .ioResult(.presetsResult(result))
                         return "case .ioResult(let result): return .ioResult(.\(forward.parentCaseName)(result))"
                     } else {
-                        // Individual case forward - not typically used for fromChildAction
-                        return "case .ioResult(let result): return .ioResult(.\(forward.parentCaseName)(result))"
+                        let valueForwarding = makeValueForwarding(forward.associatedValues)
+                        return "case .ioResult(.\(forward.targetCaseName!)\(valueForwarding.pattern)): return .ioResult(.\(forward.parentCaseName)\(valueForwarding.call))"
                     }
                 }
                 let reverseCases = reverseMappings.joined(separator: "\n                    ")

--- a/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
+++ b/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
@@ -162,7 +162,7 @@ private struct StateMachineAnalyzer {
 
                 let caseName = element.name.text
                 let associatedValues = element.parameterClause?.parameters.map { param -> AssociatedValue in
-                    let label = param.firstName?.text
+                    let label = param.firstName?.text == "_" ? nil : param.firstName?.text
                     let type = param.type.trimmedDescription
                     return AssociatedValue(label: label, type: type)
                 } ?? []

--- a/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
+++ b/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
@@ -174,7 +174,7 @@ private struct StateMachineAnalyzer {
                 let targetInfo = try parseForwardTarget(
                     from: forwardingAttribute,
                     attributeName: isValueForward ? "ForwardValue" : "Forward",
-                    requiresWholeEnum: isValueForward
+                    requiredWholeEnumType: isValueForward ? "Input" : nil
                 )
 
                 forwards.append(ForwardInfo(
@@ -216,7 +216,7 @@ private struct StateMachineAnalyzer {
     private static func parseForwardTarget(
         from attribute: AttributeSyntax,
         attributeName: String,
-        requiresWholeEnum: Bool
+        requiredWholeEnumType: String?
     ) throws -> ForwardTarget {
         guard let arguments = attribute.arguments else {
             throw MacroError.message("@\(attributeName) requires a target argument")
@@ -251,8 +251,10 @@ private struct StateMachineAnalyzer {
 
         let isWholeEnumForward = caseName == "self"
 
-        guard !requiresWholeEnum || isWholeEnumForward else {
-            throw MacroError.message("@\(attributeName) target must be in format FeatureName.Input.self (got: \(argString))")
+        if let requiredWholeEnumType {
+            guard isWholeEnumForward, enumType == requiredWholeEnumType else {
+                throw MacroError.message("@\(attributeName) target must be in format FeatureName.\(requiredWholeEnumType).self (got: \(argString))")
+            }
         }
 
         return ForwardTarget(

--- a/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
+++ b/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
@@ -466,7 +466,10 @@ private struct StateMachineAnalyzer {
             let fromChildActionBody: String
             if hasIOResultMappings {
                 // Generate reverse mapping for IOResult
-                let reverseMappings = forwards.ioResultForwards.map { forward -> String in
+                let orderedForwards = forwards.ioResultForwards
+                    .filter { !$0.isWholeEnumForward } + forwards.ioResultForwards
+                    .filter(\.isWholeEnumForward)
+                let reverseMappings = orderedForwards.map { forward -> String in
                     if forward.isWholeEnumForward {
                         // Whole enum forward: .ioResult(result) -> .ioResult(.presetsResult(result))
                         return "case .ioResult(let result): return .ioResult(.\(forward.parentCaseName)(result))"

--- a/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
+++ b/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
@@ -146,7 +146,19 @@ private struct StateMachineAnalyzer {
             guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else { continue }
 
             for element in caseDecl.elements {
-                guard let forwardAttr = findForwardAttribute(in: caseDecl) else { continue }
+                let forwardAttr = findAttribute(named: "Forward", in: caseDecl)
+                let forwardValueAttr = findAttribute(named: "ForwardValue", in: caseDecl)
+
+                guard !(forwardAttr != nil && forwardValueAttr != nil) else {
+                    throw MacroError.message("Use either @Forward or @ForwardValue on \(enumDecl.name.text).\(element.name.text), not both")
+                }
+
+                guard let forwardingAttribute = forwardAttr ?? forwardValueAttr else { continue }
+                let isValueForward = forwardValueAttr != nil
+
+                guard !isValueForward || !isIOResult else {
+                    throw MacroError.message("@ForwardValue can only be used on Input cases")
+                }
 
                 let caseName = element.name.text
                 let associatedValues = element.parameterClause?.parameters.map { param -> AssociatedValue in
@@ -155,8 +167,15 @@ private struct StateMachineAnalyzer {
                     return AssociatedValue(label: label, type: type)
                 } ?? []
 
-                // Parse the @Forward argument to extract target info
-                let targetInfo = try parseForwardTarget(from: forwardAttr)
+                if isValueForward && associatedValues.count != 1 {
+                    throw MacroError.message("@ForwardValue requires exactly one associated value on \(enumDecl.name.text).\(caseName)")
+                }
+
+                let targetInfo = try parseForwardTarget(
+                    from: forwardingAttribute,
+                    attributeName: isValueForward ? "ForwardValue" : "Forward",
+                    requiresWholeEnum: isValueForward
+                )
 
                 forwards.append(ForwardInfo(
                     parentCaseName: caseName,
@@ -165,6 +184,7 @@ private struct StateMachineAnalyzer {
                     targetEnumType: targetInfo.enumType,
                     targetCaseName: targetInfo.caseName,
                     isWholeEnumForward: targetInfo.isWholeEnumForward,
+                    isValueForward: isValueForward,
                     isIOResult: isIOResult
                 ))
             }
@@ -173,10 +193,10 @@ private struct StateMachineAnalyzer {
         return forwards
     }
 
-    private static func findForwardAttribute(in caseDecl: EnumCaseDeclSyntax) -> AttributeSyntax? {
+    private static func findAttribute(named name: String, in caseDecl: EnumCaseDeclSyntax) -> AttributeSyntax? {
         for attr in caseDecl.attributes {
             if case let .attribute(attribute) = attr,
-               isAttributeNamed(attribute, name: "Forward") {
+               isAttributeNamed(attribute, name: name) {
                 return attribute
             }
         }
@@ -193,9 +213,13 @@ private struct StateMachineAnalyzer {
         return attrName == name || attrName.hasPrefix("\(name)<") || attrName.hasPrefix("\(name)(")
     }
 
-    private static func parseForwardTarget(from attribute: AttributeSyntax) throws -> ForwardTarget {
+    private static func parseForwardTarget(
+        from attribute: AttributeSyntax,
+        attributeName: String,
+        requiresWholeEnum: Bool
+    ) throws -> ForwardTarget {
         guard let arguments = attribute.arguments else {
-            throw MacroError.message("@Forward requires a target argument")
+            throw MacroError.message("@\(attributeName) requires a target argument")
         }
 
         // The argument could be:
@@ -218,7 +242,7 @@ private struct StateMachineAnalyzer {
         let components = argString.split(separator: ".").map(String.init)
 
         guard components.count >= 3 else {
-            throw MacroError.message("@Forward target must be in format FeatureName.EnumType.caseName (got: \(argString))")
+            throw MacroError.message("@\(attributeName) target must be in format FeatureName.EnumType.caseName or FeatureName.EnumType.self (got: \(argString))")
         }
 
         let caseName = components.last!
@@ -226,6 +250,10 @@ private struct StateMachineAnalyzer {
         let featureName = components.dropLast(2).joined(separator: ".")
 
         let isWholeEnumForward = caseName == "self"
+
+        guard !requiresWholeEnum || isWholeEnumForward else {
+            throw MacroError.message("@\(attributeName) target must be in format FeatureName.Input.self (got: \(argString))")
+        }
 
         return ForwardTarget(
             featureName: featureName,
@@ -348,6 +376,10 @@ private struct StateMachineAnalyzer {
             guard let forwards = featureForwards[nestedState.featureName] else { continue }
 
             let inputMappings = forwards.inputForwards.map { forward -> String in
+                if forward.isValueForward {
+                    let valueForwarding = makeValueInputForwarding(forward.associatedValues)
+                    return "case .\(forward.parentCaseName)\(valueForwarding.pattern): return .input(\(valueForwarding.call))"
+                }
                 let valueForwarding = makeValueForwarding(forward.associatedValues)
                 return "case .\(forward.parentCaseName)\(valueForwarding.pattern): return .input(.\(forward.targetCaseName!)\(valueForwarding.call))"
             }
@@ -472,6 +504,12 @@ private struct StateMachineAnalyzer {
 
         return ("(\(bindings.joined(separator: ", ")))", "(\(args.joined(separator: ", ")))")
     }
+
+    private func makeValueInputForwarding(_ associatedValues: [AssociatedValue]) -> (pattern: String, call: String) {
+        let associatedValue = associatedValues[0]
+        let name = associatedValue.label ?? "value"
+        return ("(let \(name))", name)
+    }
 }
 
 // MARK: - Helper Types
@@ -494,6 +532,7 @@ private struct ForwardInfo {
     let targetEnumType: String
     let targetCaseName: String?
     let isWholeEnumForward: Bool
+    let isValueForward: Bool
     let isIOResult: Bool
 }
 

--- a/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
+++ b/Sources/StateMachineMacros/ComposableStateMachineMacro.swift
@@ -156,10 +156,6 @@ private struct StateMachineAnalyzer {
                 guard let forwardingAttribute = forwardAttr ?? forwardValueAttr else { continue }
                 let isValueForward = forwardValueAttr != nil
 
-                guard !isValueForward || !isIOResult else {
-                    throw MacroError.message("@ForwardValue can only be used on Input cases")
-                }
-
                 let caseName = element.name.text
                 let associatedValues = element.parameterClause?.parameters.map { param -> AssociatedValue in
                     let label = param.firstName?.text == "_" ? nil : param.firstName?.text
@@ -174,7 +170,7 @@ private struct StateMachineAnalyzer {
                 let targetInfo = try parseForwardTarget(
                     from: forwardingAttribute,
                     attributeName: isValueForward ? "ForwardValue" : "Forward",
-                    requiredWholeEnumType: isValueForward ? "Input" : nil
+                    requiredWholeEnumType: isValueForward ? (isIOResult ? "IOResult" : "Input") : nil
                 )
 
                 if targetInfo.isWholeEnumForward && !isValueForward {
@@ -184,6 +180,15 @@ private struct StateMachineAnalyzer {
                         associatedValues: associatedValues,
                         targetType: "\(targetInfo.featureName).\(targetInfo.enumType)"
                     )
+                }
+
+                if targetInfo.isWholeEnumForward,
+                   let existingForward = forwards.first(where: {
+                       $0.isWholeEnumForward &&
+                       $0.targetFeature == targetInfo.featureName &&
+                       $0.targetEnumType == targetInfo.enumType
+                   }) {
+                    throw MacroError.message("Whole-target forwarding for \(targetInfo.featureName).\(targetInfo.enumType) is already declared on \(enumDecl.name.text).\(existingForward.parentCaseName)")
                 }
 
                 forwards.append(ForwardInfo(
@@ -410,6 +415,10 @@ private struct StateMachineAnalyzer {
             }
 
             let ioResultMappings = forwards.ioResultForwards.map { forward -> String in
+                if forward.isValueForward {
+                    let valueForwarding = makeValueInputForwarding(forward.associatedValues)
+                    return "case .\(forward.parentCaseName)\(valueForwarding.pattern): return .ioResult(\(valueForwarding.call))"
+                }
                 if forward.isWholeEnumForward {
                     // Whole enum forward: case .presetsResult(let childResult) -> return .ioResult(childResult)
                     return "case .\(forward.parentCaseName)(let childResult): return .ioResult(childResult)"

--- a/Sources/StateMachineMacros/ForwardValueMacro.swift
+++ b/Sources/StateMachineMacros/ForwardValueMacro.swift
@@ -1,0 +1,15 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Marker macro for Input enum cases that forward their associated value as a child input.
+/// The `@ComposableStateMachine` macro reads this attribute.
+public struct ForwardValueMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // Marker only - no expansion needed
+        return []
+    }
+}

--- a/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
+++ b/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
@@ -120,6 +120,183 @@ final class ComposableStateMachineMacroTests: XCTestCase {
         )
     }
 
+    func testWholeEnumInputForwardingExpansion() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    @Forward(ChildFeature.Input.self)
+                    case child(ChildFeature.Input)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    case child(ChildFeature.Input)
+                }
+
+                static func reduce(_ state: State, _ action: Action) -> Transition {
+                    return switch Action.map(action) {
+                    case nil:
+                        identity
+                    case .input(let input)?:
+                        reduceInput(state, input)
+                    case .ioResult(let ioResult)?:
+                        reduceIOResult(state, ioResult)
+                    }
+                }
+
+                func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+                    let (nextState, ioEffect) = transition
+                    if let nextState {
+                        state = nextState
+                    }
+                    guard let ioEffect else {
+                        return .none
+                    }
+                    return .run { send in
+                        for try await result in runIOEffect(ioEffect) {
+                            await send(.ioResult(result))
+                        }
+                    }
+                }
+
+                @ReducerBuilder<State, Action>
+                var body: some Reducer<State, Action> {
+                    NestedStateMachine<State, Action, ChildFeature>(
+                        state: \\.child,
+                        toChildAction: { (action: Action) -> ChildFeature.Action? in
+                            guard case .input(let input) = action else {
+                                return nil
+                            }
+                        switch input {
+                        case .child(let childInput):
+                                return .input(childInput)
+                        default:
+                                return nil
+                        }
+                        },
+                        fromChildAction: { @Sendable (childAction: ChildFeature.Action) -> Action? in
+                            nil
+                        },
+                        child: {
+                            ChildFeature()
+                        }
+                    )
+
+                    Reduce { state, action in
+                            let transition = Self.reduce(state, action)
+                            return apply(transition, to: &state)
+                        }
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
+    func testIndividualIOResultForwardingExpansion() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum IOResult {
+                    @Forward(ChildFeature.IOResult.loaded)
+                    case childLoaded(Int)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum IOResult {
+                    case childLoaded(Int)
+                }
+
+                static func reduce(_ state: State, _ action: Action) -> Transition {
+                    return switch Action.map(action) {
+                    case nil:
+                        identity
+                    case .input(let input)?:
+                        reduceInput(state, input)
+                    case .ioResult(let ioResult)?:
+                        reduceIOResult(state, ioResult)
+                    }
+                }
+
+                func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+                    let (nextState, ioEffect) = transition
+                    if let nextState {
+                        state = nextState
+                    }
+                    guard let ioEffect else {
+                        return .none
+                    }
+                    return .run { send in
+                        for try await result in runIOEffect(ioEffect) {
+                            await send(.ioResult(result))
+                        }
+                    }
+                }
+
+                @ReducerBuilder<State, Action>
+                var body: some Reducer<State, Action> {
+                    NestedStateMachine<State, Action, ChildFeature>(
+                        state: \\.child,
+                        toChildAction: { (action: Action) -> ChildFeature.Action? in
+                            guard case .ioResult(let ioResult) = action else {
+                                return nil
+                            }
+                        switch ioResult {
+                        case .childLoaded(let v0):
+                                return .ioResult(.loaded(v0))
+                        default:
+                                return nil
+                        }
+                        },
+                        fromChildAction: { @Sendable (childAction: ChildFeature.Action) -> Action? in
+                            switch childAction {
+                            case .ioResult(.loaded(let v0)):
+                                return .ioResult(.childLoaded(v0))
+                            default:
+                                return nil
+                            }
+                        },
+                        child: {
+                            ChildFeature()
+                        }
+                    )
+
+                    Reduce { state, action in
+                            let transition = Self.reduce(state, action)
+                            return apply(transition, to: &state)
+                        }
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
     func testValueForwardingExpansion() {
         assertMacroExpansion(
             """
@@ -236,6 +413,120 @@ final class ComposableStateMachineMacroTests: XCTestCase {
             diagnostics: [
                 DiagnosticSpec(
                     message: "@ForwardValue requires exactly one associated value on Input.load",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: macros
+        )
+    }
+
+    func testWholeEnumForwardRequiresAssociatedValue() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    @Forward(ChildFeature.Input.self)
+                    case child
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    case child
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "Whole-enum @Forward on Input.child requires exactly one associated value of type ChildFeature.Input",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: macros
+        )
+    }
+
+    func testWholeEnumForwardRequiresSingleAssociatedValue() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum IOResult {
+                    @Forward(ChildFeature.IOResult.self)
+                    case child(ChildFeature.IOResult, ChildFeature.IOResult)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum IOResult {
+                    case child(ChildFeature.IOResult, ChildFeature.IOResult)
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "Whole-enum @Forward on IOResult.child requires exactly one associated value of type ChildFeature.IOResult",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: macros
+        )
+    }
+
+    func testWholeEnumForwardRequiresMatchingAssociatedValueType() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    @Forward(ChildFeature.Input.self)
+                    case child(String)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    case child(String)
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "Whole-enum @Forward on Input.child requires exactly one associated value of type ChildFeature.Input",
                     line: 1,
                     column: 1
                 )

--- a/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
+++ b/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
@@ -206,6 +206,92 @@ final class ComposableStateMachineMacroTests: XCTestCase {
         )
     }
 
+    func testValueForwardingTreatsUnderscoreLabelAsUnlabeled() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    @ForwardValue(NumberFactLoader.Input.self)
+                    case load(_ value: Int)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    case load(_ value: Int)
+                }
+
+                static func reduce(_ state: State, _ action: Action) -> Transition {
+                    return switch Action.map(action) {
+                    case nil:
+                        identity
+                    case .input(let input)?:
+                        reduceInput(state, input)
+                    case .ioResult(let ioResult)?:
+                        reduceIOResult(state, ioResult)
+                    }
+                }
+
+                func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+                    let (nextState, ioEffect) = transition
+                    if let nextState {
+                        state = nextState
+                    }
+                    guard let ioEffect else {
+                        return .none
+                    }
+                    return .run { send in
+                        for try await result in runIOEffect(ioEffect) {
+                            await send(.ioResult(result))
+                        }
+                    }
+                }
+
+                @ReducerBuilder<State, Action>
+                var body: some Reducer<State, Action> {
+                    NestedStateMachine<State, Action, NumberFactLoader>(
+                        state: \\.load,
+                        toChildAction: { (action: Action) -> NumberFactLoader.Action? in
+                            guard case .input(let input) = action else {
+                                return nil
+                            }
+                        switch input {
+                        case .load(let value):
+                                return .input(value)
+                        default:
+                                return nil
+                        }
+                        },
+                        fromChildAction: { @Sendable (childAction: NumberFactLoader.Action) -> Action? in
+                            nil
+                        },
+                        child: {
+                            NumberFactLoader()
+                        }
+                    )
+
+                    Reduce { state, action in
+                            let transition = Self.reduce(state, action)
+                            return apply(transition, to: &state)
+                        }
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
     func testForwardValueRequiresOneAssociatedValue() {
         assertMacroExpansion(
             """

--- a/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
+++ b/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
@@ -1,0 +1,284 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import StateMachineMacros
+
+final class ComposableStateMachineMacroTests: XCTestCase {
+    private let macros: [String: Macro.Type] = [
+        "ComposableStateMachine": ComposableStateMachineMacro.self,
+        "Forward": ForwardMacro.self,
+        "ForwardValue": ForwardValueMacro.self,
+        "NestedFeature": NestedFeatureMacro.self,
+        "NestedState": NestedStateMacro.self,
+    ]
+
+    func testExistingInputAndIOResultForwardingExpansion() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    @Forward(ChildFeature.Input.setValue)
+                    case setChildValue(value: Int)
+                }
+
+                enum IOResult {
+                    @Forward(ChildFeature.IOResult.self)
+                    case childResult(ChildFeature.IOResult)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    case setChildValue(value: Int)
+                }
+
+                enum IOResult {
+                    case childResult(ChildFeature.IOResult)
+                }
+
+                static func reduce(_ state: State, _ action: Action) -> Transition {
+                    return switch Action.map(action) {
+                    case nil:
+                        identity
+                    case .input(let input)?:
+                        reduceInput(state, input)
+                    case .ioResult(let ioResult)?:
+                        reduceIOResult(state, ioResult)
+                    }
+                }
+
+                func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+                    let (nextState, ioEffect) = transition
+                    if let nextState {
+                        state = nextState
+                    }
+                    guard let ioEffect else {
+                        return .none
+                    }
+                    return .run { send in
+                        for try await result in runIOEffect(ioEffect) {
+                            await send(.ioResult(result))
+                        }
+                    }
+                }
+
+                @ReducerBuilder<State, Action>
+                var body: some Reducer<State, Action> {
+                    NestedStateMachine<State, Action, ChildFeature>(
+                        state: \\.child,
+                        toChildAction: { (action: Action) -> ChildFeature.Action? in
+                            switch action {
+                        case .input(let input):
+                            switch input {
+                            case .setChildValue(let value):
+                                return .input(.setValue(value: value))
+                            default:
+                                return nil
+                            }
+                        case .ioResult(let ioResult):
+                            switch ioResult {
+                            case .childResult(let childResult):
+                                return .ioResult(childResult)
+                            default:
+                                return nil
+                            }
+                        }
+                        },
+                        fromChildAction: { @Sendable (childAction: ChildFeature.Action) -> Action? in
+                            switch childAction {
+                            case .ioResult(let result):
+                                return .ioResult(.childResult(result))
+                            default:
+                                return nil
+                            }
+                        },
+                        child: {
+                            ChildFeature()
+                        }
+                    )
+
+                    Reduce { state, action in
+                            let transition = Self.reduce(state, action)
+                            return apply(transition, to: &state)
+                        }
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
+    func testValueForwardingExpansion() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    @ForwardValue(NumberFactLoader.Input.self)
+                    case load(Int)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    case load(Int)
+                }
+
+                static func reduce(_ state: State, _ action: Action) -> Transition {
+                    return switch Action.map(action) {
+                    case nil:
+                        identity
+                    case .input(let input)?:
+                        reduceInput(state, input)
+                    case .ioResult(let ioResult)?:
+                        reduceIOResult(state, ioResult)
+                    }
+                }
+
+                func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+                    let (nextState, ioEffect) = transition
+                    if let nextState {
+                        state = nextState
+                    }
+                    guard let ioEffect else {
+                        return .none
+                    }
+                    return .run { send in
+                        for try await result in runIOEffect(ioEffect) {
+                            await send(.ioResult(result))
+                        }
+                    }
+                }
+
+                @ReducerBuilder<State, Action>
+                var body: some Reducer<State, Action> {
+                    NestedStateMachine<State, Action, NumberFactLoader>(
+                        state: \\.load,
+                        toChildAction: { (action: Action) -> NumberFactLoader.Action? in
+                            guard case .input(let input) = action else {
+                                return nil
+                            }
+                        switch input {
+                        case .load(let value):
+                                return .input(value)
+                        default:
+                                return nil
+                        }
+                        },
+                        fromChildAction: { @Sendable (childAction: NumberFactLoader.Action) -> Action? in
+                            nil
+                        },
+                        child: {
+                            NumberFactLoader()
+                        }
+                    )
+
+                    Reduce { state, action in
+                            let transition = Self.reduce(state, action)
+                            return apply(transition, to: &state)
+                        }
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
+    func testForwardValueRequiresOneAssociatedValue() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    @ForwardValue(NumberFactLoader.Input.self)
+                    case load(Int, String)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    case load(Int, String)
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@ForwardValue requires exactly one associated value on Input.load",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: macros
+        )
+    }
+
+    func testForwardValueCannotBeUsedOnIOResult() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var load = NumberFactLoader.State()
+                }
+
+                enum IOResult {
+                    @ForwardValue(NumberFactLoader.IOResult.self)
+                    case loadResult(NumberFactLoader.IOResult)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var load = NumberFactLoader.State()
+                }
+
+                enum IOResult {
+                    case loadResult(NumberFactLoader.IOResult)
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@ForwardValue can only be used on Input cases",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: macros
+        )
+    }
+}

--- a/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
+++ b/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
@@ -244,6 +244,44 @@ final class ComposableStateMachineMacroTests: XCTestCase {
         )
     }
 
+    func testForwardValueRequiresChildInputSelfTarget() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    @ForwardValue(NumberFactLoader.IOResult.self)
+                    case load(Int)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var load = NumberFactLoader.State()
+                }
+
+                enum Input {
+                    case load(Int)
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@ForwardValue target must be in format FeatureName.Input.self (got: NumberFactLoader.IOResult.self)",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: macros
+        )
+    }
+
     func testForwardValueCannotBeUsedOnIOResult() {
         assertMacroExpansion(
             """

--- a/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
+++ b/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
@@ -297,6 +297,105 @@ final class ComposableStateMachineMacroTests: XCTestCase {
         )
     }
 
+    func testIndividualIOResultReverseMappingsPrecedeWholeEnumCatchAll() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum IOResult {
+                    @Forward(ChildFeature.IOResult.self)
+                    case child(ChildFeature.IOResult)
+
+                    @Forward(ChildFeature.IOResult.loaded)
+                    case childLoaded(Int)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum IOResult {
+                    case child(ChildFeature.IOResult)
+                    case childLoaded(Int)
+                }
+
+                static func reduce(_ state: State, _ action: Action) -> Transition {
+                    return switch Action.map(action) {
+                    case nil:
+                        identity
+                    case .input(let input)?:
+                        reduceInput(state, input)
+                    case .ioResult(let ioResult)?:
+                        reduceIOResult(state, ioResult)
+                    }
+                }
+
+                func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+                    let (nextState, ioEffect) = transition
+                    if let nextState {
+                        state = nextState
+                    }
+                    guard let ioEffect else {
+                        return .none
+                    }
+                    return .run { send in
+                        for try await result in runIOEffect(ioEffect) {
+                            await send(.ioResult(result))
+                        }
+                    }
+                }
+
+                @ReducerBuilder<State, Action>
+                var body: some Reducer<State, Action> {
+                    NestedStateMachine<State, Action, ChildFeature>(
+                        state: \\.child,
+                        toChildAction: { (action: Action) -> ChildFeature.Action? in
+                            guard case .ioResult(let ioResult) = action else {
+                                return nil
+                            }
+                        switch ioResult {
+                        case .child(let childResult):
+                                return .ioResult(childResult)
+                                case .childLoaded(let v0):
+                                return .ioResult(.loaded(v0))
+                        default:
+                                return nil
+                        }
+                        },
+                        fromChildAction: { @Sendable (childAction: ChildFeature.Action) -> Action? in
+                            switch childAction {
+                            case .ioResult(.loaded(let v0)):
+                                return .ioResult(.childLoaded(v0))
+                                    case .ioResult(let result):
+                                return .ioResult(.child(result))
+                            default:
+                                return nil
+                            }
+                        },
+                        child: {
+                            ChildFeature()
+                        }
+                    )
+
+                    Reduce { state, action in
+                            let transition = Self.reduce(state, action)
+                            return apply(transition, to: &state)
+                        }
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
     func testValueForwardingExpansion() {
         assertMacroExpansion(
             """

--- a/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
+++ b/Tests/StateMachineMacrosTests/ComposableStateMachineMacroTests.swift
@@ -758,7 +758,7 @@ final class ComposableStateMachineMacroTests: XCTestCase {
         )
     }
 
-    func testForwardValueCannotBeUsedOnIOResult() {
+    func testForwardValueIOResultExpansion() {
         assertMacroExpansion(
             """
             @ComposableStateMachine
@@ -783,11 +783,148 @@ final class ComposableStateMachineMacroTests: XCTestCase {
                 enum IOResult {
                     case loadResult(NumberFactLoader.IOResult)
                 }
+
+                static func reduce(_ state: State, _ action: Action) -> Transition {
+                    return switch Action.map(action) {
+                    case nil:
+                        identity
+                    case .input(let input)?:
+                        reduceInput(state, input)
+                    case .ioResult(let ioResult)?:
+                        reduceIOResult(state, ioResult)
+                    }
+                }
+
+                func apply(_ transition: Transition, to state: inout State) -> Effect<Action> {
+                    let (nextState, ioEffect) = transition
+                    if let nextState {
+                        state = nextState
+                    }
+                    guard let ioEffect else {
+                        return .none
+                    }
+                    return .run { send in
+                        for try await result in runIOEffect(ioEffect) {
+                            await send(.ioResult(result))
+                        }
+                    }
+                }
+
+                @ReducerBuilder<State, Action>
+                var body: some Reducer<State, Action> {
+                    NestedStateMachine<State, Action, NumberFactLoader>(
+                        state: \\.load,
+                        toChildAction: { (action: Action) -> NumberFactLoader.Action? in
+                            guard case .ioResult(let ioResult) = action else {
+                                return nil
+                            }
+                        switch ioResult {
+                        case .loadResult(let value):
+                                return .ioResult(value)
+                        default:
+                                return nil
+                        }
+                        },
+                        fromChildAction: { @Sendable (childAction: NumberFactLoader.Action) -> Action? in
+                            switch childAction {
+                            case .ioResult(let result):
+                                return .ioResult(.loadResult(result))
+                            default:
+                                return nil
+                            }
+                        },
+                        child: {
+                            NumberFactLoader()
+                        }
+                    )
+
+                    Reduce { state, action in
+                            let transition = Self.reduce(state, action)
+                            return apply(transition, to: &state)
+                        }
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
+    func testDuplicateWholeEnumInputForwardEmitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    @Forward(ChildFeature.Input.self)
+                    case childA(ChildFeature.Input)
+
+                    @Forward(ChildFeature.Input.self)
+                    case childB(ChildFeature.Input)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var child = ChildFeature.State()
+                }
+
+                enum Input {
+                    case childA(ChildFeature.Input)
+                    case childB(ChildFeature.Input)
+                }
             }
             """,
             diagnostics: [
                 DiagnosticSpec(
-                    message: "@ForwardValue can only be used on Input cases",
+                    message: "Whole-target forwarding for ChildFeature.Input is already declared on Input.childA",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: macros
+        )
+    }
+
+    func testDuplicateWholeValueIOResultForwardEmitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            @ComposableStateMachine
+            struct ParentFeature: StateMachine {
+                struct State {
+                    @NestedState var load = NumberFactLoader.State()
+                }
+
+                enum IOResult {
+                    @ForwardValue(NumberFactLoader.IOResult.self)
+                    case loadA(NumberFactLoader.IOResult)
+
+                    @ForwardValue(NumberFactLoader.IOResult.self)
+                    case loadB(NumberFactLoader.IOResult)
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct ParentFeature: StateMachine {
+                struct State {
+                    var load = NumberFactLoader.State()
+                }
+
+                enum IOResult {
+                    case loadA(NumberFactLoader.IOResult)
+                    case loadB(NumberFactLoader.IOResult)
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "Whole-target forwarding for NumberFactLoader.IOResult is already declared on IOResult.loadA",
                     line: 1,
                     column: 1
                 )


### PR DESCRIPTION
- Allows composed state machines to forward specific `Input` case associated values when the nested state machine `Input` type doesn't have a corresponding enum case but the `Input` type is the value itself.

```swift
@ForwardValue(NumberFactLoader.Input.self)
case load(Int)
```